### PR TITLE
添加阻止ign.com跳转到ign中国的规则

### DIFF
--- a/chinese.txt
+++ b/chinese.txt
@@ -6,3 +6,4 @@ ruanyifeng.com#$#abort-on-property-read setTimeout
 xianzhenyuan.cn#$#abort-on-property-read ad
 rjno1.com#$#abort-current-inline-script window.setTimeout
 4399.com#$#abort-on-property-read defaultbackgroundimg
+ign.com#$#abort-on-property-read ZiffIntl


### PR DESCRIPTION
From https://www.zhihu.com/question/64877835

访问`ign.com`会自动跳转到`ign.中国`

这个小脚本是我根据那个油猴脚本写的，我这边测试是有效的。

不过我想请问一下，您能看出原作者是怎么发现这个的吗？我搜`ZiffIntl`完全搜不到在哪里定义了。