### PR TITLE
Add uBlock Origin agent to cjx-ublock.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-*.txt auto
+*.txt auto linguist-language=AdBlock linguist-detectable
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/cjx-ublock.txt
+++ b/cjx-ublock.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: CJX's uBlock list
 ! Expires: 4 days
 ! Homepage: https://github.com/cjx82630/cjxlist


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401